### PR TITLE
fix: 21406 zero address check for contract call

### DIFF
--- a/system-contract-testing/test/hip-1215/hip1215-2-scheduleCall.js
+++ b/system-contract-testing/test/hip-1215/hip1215-2-scheduleCall.js
@@ -158,30 +158,6 @@ describe("HIP-1215 System Contract testing. scheduleCall()", () => {
       );
     });
 
-    it("should succeed schedule but fail execution with invalid contract deploy", async () => {
-      await testScheduleCallAndSign(
-        "scheduleCall fail invalid contract deploy",
-        ethers.ZeroAddress,
-        0n,
-        () => "0xabc123",
-        // in this case schedule creation is SUCCESS, but schedule execution fails with INVALID_ETHEREUM_TRANSACTION
-        "INVALID_ETHEREUM_TRANSACTION",
-      );
-    });
-
-    it("should succeed schedule but fail execution with valid contract deploy", async () => {
-      const deployContract = await ethers.getContractFactory(
-        "HIP1215DeployContract",
-      );
-      await testScheduleCallAndSign(
-        "scheduleCall fail valid contract deploy",
-        ethers.ZeroAddress,
-        0n,
-        () => deployContract.bytecode,
-        "INVALID_ETHEREUM_TRANSACTION",
-      );
-    });
-
     it("should change the state after schedule executed", async () => {
       const [testId, expirySecond, scheduleTx] = await testScheduleCallAndSign(
         "scheduleCall state",
@@ -311,6 +287,37 @@ describe("HIP-1215 System Contract testing. scheduleCall()", () => {
       await testScheduleCallEvent(
         tx,
         ResponseCodeEnum.SCHEDULE_EXPIRATION_TIME_MUST_BE_HIGHER_THAN_CONSENSUS_TIME.valueOf(),
+      );
+    });
+
+    it("should fail with zero 'to' address and invalid contract deploy", async () => {
+      const tx = await hip1215.scheduleCall(
+        ethers.ZeroAddress,
+        getExpirySecond(),
+        GAS_LIMIT_1_000_000.gasLimit,
+        0,
+        "0xabc123",
+      );
+      await testScheduleCallEvent(
+        tx,
+        ResponseCodeEnum.INVALID_CONTRACT_ID.valueOf(),
+      );
+    });
+
+    it("should fail with zero 'to' address and valid contract deploy", async () => {
+      const deployContract = await ethers.getContractFactory(
+        "HIP1215DeployContract",
+      );
+      const tx = await hip1215.scheduleCall(
+        ethers.ZeroAddress,
+        getExpirySecond(),
+        GAS_LIMIT_1_000_000.gasLimit,
+        0,
+        deployContract.bytecode,
+      );
+      await testScheduleCallEvent(
+        tx,
+        ResponseCodeEnum.INVALID_CONTRACT_ID.valueOf(),
       );
     });
   });

--- a/system-contract-testing/test/hip-1215/hip1215-3-scheduleCallWithPayer.js
+++ b/system-contract-testing/test/hip-1215/hip1215-3-scheduleCallWithPayer.js
@@ -176,31 +176,6 @@ describe("HIP-1215 System Contract testing. scheduleCallWithPayer()", () => {
       );
     });
 
-    it("should succeed schedule but fail execution with invalid contract deploy", async () => {
-      await testScheduleCallWithPayerAndSign(
-        "scheduleCallWithPayer fail invalid contract deploy",
-        ethers.ZeroAddress,
-        signers[1].address,
-        0n,
-        () => "0xabc123",
-        "INVALID_ETHEREUM_TRANSACTION",
-      );
-    });
-
-    it("should succeed schedule but fail execution with valid contract deploy", async () => {
-      const deployContract = await ethers.getContractFactory(
-        "HIP1215DeployContract",
-      );
-      await testScheduleCallWithPayerAndSign(
-        "scheduleCallWithPayer fail valid contract deploy",
-        ethers.ZeroAddress,
-        signers[1].address,
-        0n,
-        () => deployContract.bytecode,
-        "INVALID_ETHEREUM_TRANSACTION",
-      );
-    });
-
     it("should change the state after schedule executed", async () => {
       const [testId, expirySecond, scheduleTx] =
         await testScheduleCallWithPayerAndSign(
@@ -383,6 +358,39 @@ describe("HIP-1215 System Contract testing. scheduleCallWithPayer()", () => {
       await testScheduleCallEvent(
         tx,
         ResponseCodeEnum.SCHEDULE_EXPIRATION_TIME_MUST_BE_HIGHER_THAN_CONSENSUS_TIME.valueOf(),
+      );
+    });
+
+    it("should fail with zero 'to' address and invalid contract deploy", async () => {
+      const tx = await hip1215.scheduleCallWithPayer(
+        ethers.ZeroAddress,
+        signers[1].address,
+        getExpirySecond(),
+        GAS_LIMIT_1_000_000.gasLimit,
+        0,
+        "0xabc123",
+      );
+      await testScheduleCallEvent(
+        tx,
+        ResponseCodeEnum.INVALID_CONTRACT_ID.valueOf(),
+      );
+    });
+
+    it("should fail with zero 'to' address and valid contract deploy", async () => {
+      const deployContract = await ethers.getContractFactory(
+        "HIP1215DeployContract",
+      );
+      const tx = await hip1215.scheduleCallWithPayer(
+        ethers.ZeroAddress,
+        signers[1].address,
+        getExpirySecond(),
+        GAS_LIMIT_1_000_000.gasLimit,
+        0,
+        deployContract.bytecode,
+      );
+      await testScheduleCallEvent(
+        tx,
+        ResponseCodeEnum.INVALID_CONTRACT_ID.valueOf(),
       );
     });
   });

--- a/system-contract-testing/test/hip-1215/hip1215-4-executeCallOnPayerSignature.js
+++ b/system-contract-testing/test/hip-1215/hip1215-4-executeCallOnPayerSignature.js
@@ -173,31 +173,6 @@ describe("HIP-1215 System Contract testing. executeCallOnPayerSignature()", () =
       );
     });
 
-    it("should succeed schedule but fail execution with invalid contract deploy", async () => {
-      await testExecuteCallOnPayerSignatureAndSign(
-        "executeCallOnPayerSignature fail invalid contract deploy",
-        ethers.ZeroAddress,
-        signers[1].address,
-        0n,
-        () => "0xabc123",
-        "INVALID_ETHEREUM_TRANSACTION",
-      );
-    });
-
-    it("should succeed schedule but fail execution with valid contract deploy", async () => {
-      const deployContract = await ethers.getContractFactory(
-        "HIP1215DeployContract",
-      );
-      await testExecuteCallOnPayerSignatureAndSign(
-        "executeCallOnPayerSignature fail valid contract deploy",
-        ethers.ZeroAddress,
-        signers[1].address,
-        0n,
-        () => deployContract.bytecode,
-        "INVALID_ETHEREUM_TRANSACTION",
-      );
-    });
-
     it("should change the state after schedule executed", async () => {
       const [testId, scheduleTx] = await testExecuteCallOnPayerSignatureAndSign(
         "executeCallOnPayerSignature state",
@@ -374,6 +349,39 @@ describe("HIP-1215 System Contract testing. executeCallOnPayerSignature()", () =
       await testScheduleCallEvent(
         tx,
         ResponseCodeEnum.SCHEDULE_EXPIRATION_TIME_MUST_BE_HIGHER_THAN_CONSENSUS_TIME.valueOf(),
+      );
+    });
+
+    it("should fail with zero 'to' address and invalid contract deploy", async () => {
+      const tx = await hip1215.executeCallOnPayerSignature(
+        ethers.ZeroAddress,
+        signers[1].address,
+        getExpirySecond(),
+        GAS_LIMIT_1_000_000.gasLimit,
+        0,
+        "0xabc123",
+      );
+      await testScheduleCallEvent(
+        tx,
+        ResponseCodeEnum.INVALID_CONTRACT_ID.valueOf(),
+      );
+    });
+
+    it("should fail with zero 'to' address and valid contract deploy", async () => {
+      const deployContract = await ethers.getContractFactory(
+        "HIP1215DeployContract",
+      );
+      const tx = await hip1215.executeCallOnPayerSignature(
+        ethers.ZeroAddress,
+        signers[1].address,
+        getExpirySecond(),
+        GAS_LIMIT_1_000_000.gasLimit,
+        0,
+        deployContract.bytecode,
+      );
+      await testScheduleCallEvent(
+        tx,
+        ResponseCodeEnum.INVALID_CONTRACT_ID.valueOf(),
       );
     });
   });


### PR DESCRIPTION
**Description**:
[HIP-1215](https://github.com/hiero-ledger/hiero-improvement-proposals/blob/main/HIP/hip-1215.md) do not support ContractCreate operation.
As we don't support it we can fail fast, If `to` parameter equal `zero address` we should return `INVALID_CONTRACT_ID`.

**Related issue(s)**:

Fixes [#21406](https://github.com/hiero-ledger/hiero-consensus-node/issues/21406)

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
