### PR TITLE
Fix `CREATE2` action in SDK-EthTx executor

### DIFF
--- a/evm-gas-schedule-compatibility-regression/src/executor/hedera/sdk-ethtx/action/create-via-factory-deterministic.js
+++ b/evm-gas-schedule-compatibility-regression/src/executor/hedera/sdk-ethtx/action/create-via-factory-deterministic.js
@@ -3,7 +3,7 @@
 const { ethers: { ContractFactory, Wallet, Contract } } = require('ethers');
 const hedera = require('../../client');
 const { loadArtifact } = require('../../../../utils/artifact');
-const { options } = require('../../../evm/options');
+const { options, DEFAULT_GAS_LIMIT } = require('../../../evm/options');
 
 const [factoryArtifact, counterArtifact] = [
   loadArtifact('Factory'),

--- a/evm-gas-schedule-compatibility-regression/test/test.js
+++ b/evm-gas-schedule-compatibility-regression/test/test.js
@@ -49,6 +49,7 @@ for (const test of tests) {
                                 result = await runners[executor].run([testCase.code]);
                                 if (!result.success) result = await runners[executor].run([testCase.code]);
                             } catch (e) { // try twice;
+                                console.error(e);
                                 result = await runners[executor].run([testCase.code]);
                             }
                             assert.notEqual(result.length, 0, `Failed to run ${testCase.name} on the ${executor} executor, no new transactions were found`);


### PR DESCRIPTION
**Description**:

This PR fixes the `CREATE2` action in SDK-EthTx executor. The variable `DEFAULT_GAS_LIMIT` was defined.

In addition, to have better debugging support, when the action fails it's displayed in the console.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
