### PR TITLE
chore: bump MN tag version

### DIFF
--- a/evm-functional-testing/local/mn-values.yaml
+++ b/evm-functional-testing/local/mn-values.yaml
@@ -2,7 +2,7 @@ web3:
   image:
     registry: gcr.io
     repository: mirrornode/hedera-mirror-web3
-    tag: 0.156.0-SNAPSHOT
+    tag: 0.156.0-rc1
   resources:
     requests:
       memory: 300Mi
@@ -20,7 +20,7 @@ rest:
   image:
     registry: gcr.io
     repository: mirrornode/hedera-mirror-rest
-    tag: 0.156.0-SNAPSHOT
+    tag: 0.156.0-rc1
   resources:
     requests:
       memory: 300Mi
@@ -33,7 +33,7 @@ importer:
   image:
     registry: gcr.io
     repository: mirrornode/hedera-mirror-importer
-    tag: 0.156.0-SNAPSHOT
+    tag: 0.156.0-rc1
   resources:
     requests:
       memory: 400Mi


### PR DESCRIPTION
**Description**:
Bumping MN tag version to 0.156.0-rc1

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
